### PR TITLE
update to v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [1.2.1] - 2025-07-31
+
+### New Features
+- **Sola Busca Tarot Deck Support**:
+  - Added full support for the historical Sola Busca Tarot deck
+  - Images sourced from Wikimedia Commons and rendered with high fidelity
+  - Deck selectable from the deck manager alongside Rider-Waite and Marseille
+
+- **Universal Zoom Slider**:
+  - Added a global zoom control slider to set overall card scaling
+  - Affects all cards in the spread uniformly for personalized viewing comfort
+
+- **Strength–Justice Swap Option**:
+  - Added checkbox setting to swap cards VIII and XI (Strength and Justice)
+  - Supports historical deck orders like Tarot de Marseille
+  - Swap applies dynamically per selected deck where applicable
+
+- **Dock Visibility Toggles**:
+  - Under the **View** menu, users can now toggle visibility of left/right docks
+  - Allows full focus on the card spread without UI distractions
+ 
+- **Deck Renaming Utility Dialog**:
+  - New tool to help users rename cards of custom digital decks
+  - Automatically converts filenames to the naming convention used by TarotCaster
+  - Ensures smooth import and compatibility with app features
+
+### Visual and Technical Enhancements
+- Improved card rendering clarity with updated scaling and anti-aliasing techniques
+- Enhanced sharpness and detail for all decks, especially at higher zoom levels
+- Continued optimization of rendering pipeline for smoother performance
+- General code cleanup and minor polish for better maintainability and stability
+
 ## [1.2.0] - 2025-05-16
 
 ### New Features

--- a/CREDITS.txt
+++ b/CREDITS.txt
@@ -1,0 +1,18 @@
+#### Rider-Waite Tarot
+- Original Rider-Waite Tarot deck artwork by Pamela Colman Smith under the direction of Arthur Edward Waite
+- Images sourced from [Wikimedia Commons](https://commons.wikimedia.org/wiki/Category:Rider-Waite_tarot_deck)
+- These images are in the public domain in the United States, the EU and globally because their copyright has expired
+
+#### Tarot de Marseille
+- Traditional Tarot de Marseille deck, a historical tarot pattern originating from southern France
+- Images sourced from [Wikimedia Commons](https://commons.wikimedia.org/wiki/Category:Tarot_de_Marseille_(Single_Cards))
+- These images are in the public domain due to their age and historical nature
+
+#### Sola Busca Tarot  
+- The Sola Busca Tarot is a 15th-century Italian tarot deck, notable as the oldest complete tarot deck known and for being the first to depict full scenes on the minor arcana  
+- Images sourced from [Wikimedia Commons](https://commons.wikimedia.org/wiki/Category:Sola-Busca_tarot_deck)  
+- These images are in the public domain due to their age and historical significance
+
+### Tarot Interpretations
+- Traditional card meanings adapted from [Corpora Project](https://github.com/dariusk/corpora/blob/master/data/divination/tarot_interpretations.json)
+- AI interpretations powered by Mistral AI

--- a/io.github.alamahant.TarotCaster.yaml
+++ b/io.github.alamahant.TarotCaster.yaml
@@ -16,4 +16,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/alamahant/TarotCaster.git
-        tag: v1.2.0
+        tag: v1.2.1


### PR DESCRIPTION
## [1.2.1] - 2025-07-31

### New Features
- **Sola Busca Tarot Deck Support**:
  - Added full support for the historical Sola Busca Tarot deck
  - Images sourced from Wikimedia Commons and rendered with high fidelity
  - Deck selectable from the deck manager alongside Rider-Waite and Marseille

- **Universal Zoom Slider**:
  - Added a global zoom control slider to set overall card scaling
  - Affects all cards in the spread uniformly for personalized viewing comfort

- **Strength–Justice Swap Option**:
  - Added checkbox setting to swap cards VIII and XI (Strength and Justice)
  - Supports historical deck orders like Tarot de Marseille
  - Swap applies dynamically per selected deck where applicable

- **Dock Visibility Toggles**:
  - Under the **View** menu, users can now toggle visibility of left/right docks
  - Allows full focus on the card spread without UI distractions
 
- **Deck Renaming Utility Dialog**:
  - New tool to help users rename cards of custom digital decks
  - Automatically converts filenames to the naming convention used by TarotCaster
  - Ensures smooth import and compatibility with app features
