### PR TITLE
update to v1.2.5 - fix critical crash when saving spread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+
+## [1.2.5] - 2026-04-26
+
+### Added
+- **Open Data Directory**: New action to open user data folder in native file manager
+  - Supports Nautilus, Dolphin, Thunar, and other file managers
+  - Access your tarot decks, spreads, and settings directly from file manager
+
+- **Create Data Symlink**: Create symlink from Flatpak sandbox to any location in your home directory
+  - Easy access to app data without navigating Flatpak directories
+  - Useful for backup, syncing, or manual deck management
+
+### UI Improvements
+- **Cleaner Interface**: Moved "Ask a Question to AI" functionality behind a dedicated dialog
+  - Reduces main window clutter
+  - Access via button 
+  - More focused AI interaction experience
+
+### Bug Fixes
+- Fixed critical crash when saving readings without opening question dialog first
+
+---
+
 ## [1.2.4] - 2026-04-26
 
 ### Added

--- a/io.github.alamahant.TarotCaster.yml
+++ b/io.github.alamahant.TarotCaster.yml
@@ -15,5 +15,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/alamahant/TarotCaster.git
-        tag: v1.2.4
-        commit: 71d7e25510dc2dfa1f228c997eec0c2cf9b8d371
+        tag: v1.2.5
+        commit: 4e09904b0e73de2571fa6e0c88e85e41e0121141


### PR DESCRIPTION
## [1.2.5] - 2026-04-26

### Added
- **Open Data Directory**: New action to open user data folder in native file manager
  - Supports Nautilus, Dolphin, Thunar, and other file managers
  - Access your tarot decks, spreads, and settings directly from file manager

- **Create Data Symlink**: Create symlink from Flatpak sandbox to any location in your home directory
  - Easy access to app data without navigating Flatpak directories
  - Useful for backup, syncing, or manual deck management

### UI Improvements
- **Cleaner Interface**: Moved "Ask a Question to AI" functionality behind a dedicated dialog
  - Reduces main window clutter
  - Access via button 
  - More focused AI interaction experience

### Bug Fixes
- Fixed critical crash when saving readings without opening question dialog first

---
