### PR TITLE
update to v1.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [1.2.7] - 2026-05-17
+
+### Added
+- **Show Spread in Different Deck**: View any existing spread with any installed deck
+  - Non-modal dialog prompts user to select a different deck
+  - Spread redraws instantly with the newly selected deck
+  - Compare how different decks represent the same reading
+
+- **Import Physical Cards**: Manually assign physical tarot cards to spread positions
+  - Left panel displays all available cards (00-77) with names
+  - Right panel shows spread positions with names
+  - Assign any card to any position with upright/reversed toggle
+  - Prevents duplicate card assignments across positions
+  - Validates all positions have cards before saving
+  - Saves imported spreads as `.tarot` files
+  - Automatically creates journal entry for imported readings
+
+---
+
 ## [1.2.6] - 2026-05-12
 
 ### Added

--- a/io.github.alamahant.TarotCaster.yml
+++ b/io.github.alamahant.TarotCaster.yml
@@ -15,5 +15,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/alamahant/TarotCaster.git
-        tag: v1.2.6
-        commit: 3ea6059c811f3c3fb397660195545d458c640cd3
+        tag: v1.2.7
+        commit: 45e1daced5f0427465954f2a8bc83ff10b6ceda0


### PR DESCRIPTION
## [1.2.7] - 2026-05-17

### Added
- **Show Spread in Different Deck**: View any existing spread with any installed deck
  - Non-modal dialog prompts user to select a different deck
  - Spread redraws instantly with the newly selected deck
  - Compare how different decks represent the same reading

- **Import Physical Cards**: Manually assign physical tarot cards to spread positions
  - Left panel displays all available cards (00-77) with names
  - Right panel shows spread positions with names
  - Assign any card to any position with upright/reversed toggle
  - Prevents duplicate card assignments across positions
  - Validates all positions have cards before saving
  - Saves imported spreads as `.tarot` files
  - Automatically creates journal entry for imported readings

---