### PR TITLE
Update to v1.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.2.9] - 2026-06-10
+
+### Added
+- Dynamic card scaling based on screen resolution (10% width, 15% height)
+- Adaptive spacing for all spreads (Celtic Cross, Horseshoe, Zodiac)
+- Auto-adjusting cards per row in full deck view (6-10 based on screen width)
+
+### Changed
+- Removed obsolete Qt high DPI attributes
+- Optimized render hints for sharper card images
+
+### Fixed
+- Card overlapping in Celtic Cross spread on high resolutions
+
 ## [1.2.8] - 2026-05-25
 
 ### Added

--- a/io.github.alamahant.TarotCaster.yml
+++ b/io.github.alamahant.TarotCaster.yml
@@ -15,5 +15,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/alamahant/TarotCaster.git
-        tag: v1.2.8
-        commit: 12fe4a02223fe5e5e1fa29157c0f74fa1d380c76
+        tag: v1.2.9
+        commit: dca88948c14f7cd57473db0c6a3bea77bc70e10b


### PR DESCRIPTION
## [1.2.9] - 2026-06-10

### Added
- Dynamic card scaling based on screen resolution (10% width, 15% height)
- Adaptive spacing for all spreads (Celtic Cross, Horseshoe, Zodiac)
- Auto-adjusting cards per row in full deck view (6-10 based on screen width)

### Changed
- Removed obsolete Qt high DPI attributes
- Optimized render hints for sharper card images

### Fixed
- Card overlapping in Celtic Cross spread on high resolutions
- --
- --